### PR TITLE
Changed IAM Role, Group, and Permission data type names

### DIFF
--- a/src/plugin/connector/logging_connector.py
+++ b/src/plugin/connector/logging_connector.py
@@ -1,6 +1,7 @@
 import logging
 from plugin.connector import GoogleCloudConnector
-
+import requests
+import google.auth.transport.requests
 __all__ = ["LoggingConnector"]
 
 _LOGGER = logging.getLogger("spaceone")
@@ -20,3 +21,57 @@ class LoggingConnector(GoogleCloudConnector):
 
         entries = response.get("entries", [])
         return entries
+
+    def get_all_service_account_last_authenticated_time(self, project_id: str):
+        return self._get_all_service_account_last_authenticated_time(project_id, is_key=False)
+
+    def get_all_service_account_key_last_authenticated_time(self, project_id: str):
+        return self._get_all_service_account_last_authenticated_time(project_id, is_key=True)
+
+    def _get_all_service_account_last_authenticated_time(self, project_id: str, is_key: bool):
+        activity_type = "serviceAccountLastAuthentication" if not is_key else "serviceAccountKeyLastAuthentication"
+        page_size = 150  # TODO: Check what's the maximum
+        url = f"https://policyanalyzer.googleapis.com/v1/projects/{project_id}/locations/global/activityTypes/{activity_type}/activities:query?pageSize={page_size}"
+        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+        credentials = self.credentials.with_scopes(scopes)
+        request = google.auth.transport.requests.Request()
+        credentials.refresh(request)
+        token = credentials.token
+        headers = {
+            "Authorization": f"Bearer {token}"
+        }
+        sa_id_to_last_authenticated_time = {}
+        next_page_token = ""
+        while True:
+            response = requests.get(url+next_page_token, headers=headers)
+            if response.status_code != 200:
+                error_message = f"API request failed with status code {response.status_code}: {response.text}"
+                _LOGGER.debug(f"[{self.__repr__()}] Error: {error_message}", exc_info=True)
+                if response.status_code == 403:
+                    return None
+                return sa_id_to_last_authenticated_time
+            activities = response.json().get('activities', [])
+            if not activities:
+                break
+            for one_sa_dict in activities:
+
+                sa_id = one_sa_dict.get('activity', {}).get('serviceAccount', {}).get('serviceAccountId', '')
+                sa_id = sa_id if sa_id else one_sa_dict.get('activity', {}).get('serviceAccountKey', {}).get('serviceAccountId', '')
+
+                last_authenticated_time = one_sa_dict.get('activity', {}).get('lastAuthenticatedTime', '')
+
+                if is_key:
+
+                    key_id = one_sa_dict.get('fullResourceName', '').split("/")[-1]
+
+                    if sa_id not in sa_id_to_last_authenticated_time:
+                        sa_id_to_last_authenticated_time[sa_id] = {}
+                    sa_id_to_last_authenticated_time[sa_id][key_id] = last_authenticated_time
+                else:
+                    sa_id_to_last_authenticated_time[sa_id] = last_authenticated_time
+
+            next_page_token = response.json().get('nextPageToken')
+            if not next_page_token:
+                break
+            url += "&pageToken="
+        return sa_id_to_last_authenticated_time

--- a/src/plugin/manager/iam/group_manager.py
+++ b/src/plugin/manager/iam/group_manager.py
@@ -73,6 +73,7 @@ class GroupManager(ResourceManager):
         for member in members:
             member_name = member.get("name")
             member_info = self.identity_connector.get_membership(member_name)
+            member_info["memberType"] = member_info.pop("type")
             roles = member_info.get("roles", [])
             if len(roles) > 1:
                 for role in roles:

--- a/src/plugin/manager/iam/permission_manager.py
+++ b/src/plugin/manager/iam/permission_manager.py
@@ -79,7 +79,7 @@ class PermissionManager(ResourceManager):
         organization_id = organization.get("name")
         organization_name = organization.get("displayName")
         target = {
-            "type": "ORGANIZATION",
+            "targetType": "ORGANIZATION",
             "id": organization_id,
             "name": organization_name,
             "location": organization_name
@@ -93,7 +93,7 @@ class PermissionManager(ResourceManager):
         folder_name = folder.get("displayName")
 
         target = {
-            "type": "FOLDER",
+            "targetType": "FOLDER",
             "id": folder_id,
             "name": folder_name,
             "location": self.get_folder_location(folder_id),
@@ -108,7 +108,7 @@ class PermissionManager(ResourceManager):
         project_name = project.get("name")
 
         target = {
-            "type": "PROJECT",
+            "targetType": "PROJECT",
             "id": project_id,
             "name": project_name,
             "location": self.get_project_location(project_id),
@@ -122,7 +122,7 @@ class PermissionManager(ResourceManager):
         binding_info = {
             "target": target,
         }
-        target_type = target.get("type")
+        target_type = target.get("targetType")
         target_name = target.get("name")
 
         role_id = binding.get("role")
@@ -155,7 +155,7 @@ class PermissionManager(ResourceManager):
 
             if member not in self.permission_info:
                 self.permission_info[member] = {
-                    "type": member_type,
+                    "memberType": member_type,
                     "memberId": member_id,
                     "memberName": member_id,
                     "bindings": [],
@@ -168,7 +168,7 @@ class PermissionManager(ResourceManager):
                         self.permission_info[member]["memberName"] = self.service_account_info[member_id].get("name")
                         self.permission_info[member]["projectId"] = self.service_account_info[member_id].get("projectId")
                     else:
-                        self.permission_info[member]["type"] = "googleManagedServiceAccount"
+                        self.permission_info[member]["memberType"] = "googleManagedServiceAccount"
                         if target_type == "PROJECT":
                             self.permission_info[member]["projectId"] = target["id"]
 

--- a/src/plugin/manager/iam/role_manager.py
+++ b/src/plugin/manager/iam/role_manager.py
@@ -72,13 +72,13 @@ class RoleManager(ResourceManager):
         # Get role details
         if role_type == "PROJECT":
             role_details = self.iam_connector.get_project_role(role_id)
-            role["role_type"] = "CUSTOM"
+            role["roleType"] = "CUSTOM"
         elif role_type == "ORGANIZATION":
             role_details = self.iam_connector.get_organization_role(role_id)
-            role["role_type"] = "CUSTOM"
+            role["roleType"] = "CUSTOM"
         else:
             role_details = self.iam_connector.get_role(role_id)
-            role["role_type"] = role_type
+            role["roleType"] = role_type
 
         role["includedPermissions"] = role_details.get("includedPermissions", [])
         role["permissionCount"] = len(role["includedPermissions"])

--- a/src/plugin/manager/iam/service_account_manager.py
+++ b/src/plugin/manager/iam/service_account_manager.py
@@ -30,6 +30,8 @@ class ServiceAccountManager(ResourceManager):
             "FOLDER": {},
             "PROJECT": {},
         }
+        self.sa_id_to_last_authenticated_time = {}
+        self.sa_key_to_last_authenticated_time = {}
 
     def collect_cloud_services(self, options: dict, secret_data: dict, schema: str) -> Generator[dict, None, None]:
         self.iam_connector = IAMConnector(options, secret_data, schema)
@@ -38,14 +40,23 @@ class ServiceAccountManager(ResourceManager):
 
         # Get all projects
         projects = self.rm_v3_connector.list_all_projects()
-        for project in projects:
-            if project["projectId"].startswith("sys-"):
-                continue
+        if not projects:
+            yield from self.collect_service_accounts(secret_data.get("project_id"))
+        else:
+            for project in projects:
+                if project["projectId"].startswith("sys-"):
+                    continue
 
-            yield from self.collect_service_accounts(project["projectId"])
+                yield from self.collect_service_accounts(project["projectId"])
 
     def collect_service_accounts(self, project_id: str) -> Generator[dict, None, None]:
         service_accounts = self.iam_connector.list_service_accounts(project_id)
+        self.sa_id_to_last_authenticated_time = \
+            self.logging_connector.get_all_service_account_last_authenticated_time(project_id=project_id)
+
+        self.sa_key_to_last_authenticated_time = \
+            self.logging_connector.get_all_service_account_key_last_authenticated_time(project_id=project_id)
+
         for service_account in service_accounts:
             yield self.make_cloud_service_info(service_account, project_id)
 
@@ -61,9 +72,16 @@ class ServiceAccountManager(ResourceManager):
             service_account["status"] = "ENABLED"
 
         # Get service account keys
-        keys = self.get_service_account_keys(email, project_id)
+        keys = self.get_service_account_keys(email, project_id, unique_id)
         service_account["keys"] = keys
         service_account["keyCount"] = len(keys)
+
+        if self.sa_id_to_last_authenticated_time is None:
+            service_account["lastAuthenticated"] = None
+            service_account["policyAnalyzerEnabled"] = False
+        else:
+            service_account["lastAuthenticated"] = self.sa_id_to_last_authenticated_time.get(unique_id)
+            service_account["policyAnalyzerEnabled"] = True
 
         return make_cloud_service(
             name=name,
@@ -81,11 +99,13 @@ class ServiceAccountManager(ResourceManager):
             # data_format="grpc",
         )
 
-    def get_service_account_keys(self, email: str, project_id: str) -> list:
+    def get_service_account_keys(self, email: str, project_id: str, unique_id: str) -> list:
         keys = self.iam_connector.list_service_account_keys(email, project_id)
         for key in keys:
             key["name"] = key.get("name").split("/")[-1]
             key["status"] = "ACTIVE"
+            key["lastAuthenticated"] = self.sa_key_to_last_authenticated_time.get(unique_id, {}).get(key["name"]) if self.sa_key_to_last_authenticated_time else None
+
             creation_time = key.get("validAfterTime")
             expiration_time = key.get("validBeforeTime")
 

--- a/src/plugin/metadata/group.yaml
+++ b/src/plugin/metadata/group.yaml
@@ -22,7 +22,7 @@ tabs.0:
   search:
     - key: data.members.preferredMemberKey.id
       name: Member
-    - key: data.members.type
+    - key: data.members.memberType
       name: Type
     - key: data.members.role
       name: Role in Group

--- a/src/plugin/metadata/permission.yaml
+++ b/src/plugin/metadata/permission.yaml
@@ -1,7 +1,7 @@
 search:
   fields:
     - Principal: data.memberId
-    - Type: data.type
+    - Type: data.memberType
       type: enum
       enums:
         - domain: yellow.500
@@ -30,7 +30,7 @@ search:
           label: Custom
     - Target ID: data.bindings.target.id
     - Target Name: data.bindings.target.name
-    - Target Type: data.bindings.target.type
+    - Target Type: data.bindings.target.targetType
       type: enum
       enums:
         - ORGANIZATION: blue.500
@@ -42,11 +42,11 @@ search:
 
 table:
   sort:
-    key: data.type
+    key: data.memberType
   fields:
     - Principal: data.memberId
       is_optional: true
-    - Type: data.type
+    - Type: data.memberType
       type: enum
       enums:
         - domain: yellow.500
@@ -83,7 +83,7 @@ tabs.0:
           label: Custom
     - key: data.bindings.role.id
       name: Role ID
-    - key: data.bindings.target.type
+    - key: data.bindings.target.targetType
       name: Target Type
       enums:
         ORGANIZATION:
@@ -121,7 +121,7 @@ tabs.0:
           options:
             layout:
               type: "raw"
-    - Target Type: target.type
+    - Target Type: target.targetType
       type: enum
       enums:
         - ORGANIZATION: blue.500

--- a/src/plugin/metadata/role.yaml
+++ b/src/plugin/metadata/role.yaml
@@ -8,7 +8,7 @@ search:
         - DISABLED: red.500
           label: Disabled
     - Role ID: data.name
-    - Type: data.role_type
+    - Type: data.roleType
       type: enum
       enums:
         - PREDEFINED: gray.500
@@ -22,7 +22,7 @@ search:
 
 table:
   sort:
-    key: data.role_type
+    key: data.roleType
   fields:
     - Status: data.status
       type: enum
@@ -37,7 +37,7 @@ table:
       is_optional: true
     - Permission Count: data.permissionCount
       data_type: integer
-    - Type: data.role_type
+    - Type: data.roleType
       type: enum
       enums:
         - PREDEFINED: gray.500
@@ -64,7 +64,7 @@ tabs.0:
           name: Disabled
           type: state
     - Description: data.description
-    - Type: data.role_type
+    - Type: data.roleType
       type: enum
       enums:
         - PREDEFINED: gray.500

--- a/src/plugin/metadata/service_account.yaml
+++ b/src/plugin/metadata/service_account.yaml
@@ -37,6 +37,18 @@ table:
     - Description: data.description
       is_optional: true
     - Key Count: data.keyCount
+    - Analyzer Enabled: data.policyAnalyzerEnabled
+      type: enum
+      enums:
+        - true: green.500
+          name: Enabled
+        - false: red.500
+          name: Disabled
+      is_optional: true
+    - Last Activity: data.lastAuthenticated
+      type: datetime
+      display_format: 'YYYY-MM-DD'
+      source_type: iso8601
     - OAuth2 Client ID: data.oauth2ClientId
     - Google Project ID: account
     - Unique ID: data.uniqueId
@@ -100,6 +112,10 @@ tabs.1:
         - "EXPIRED": red.500
           name: Expired
           type: state
+    - Last Activity: data.lastAuthenticated
+      type: datetime
+      display_format: 'YYYY-MM-DD'
+      source_type: iso8601
     - Type: keyOrigin
       type: enum
       enums:

--- a/src/plugin/metrics/IAM/Group/group_member_count.yaml
+++ b/src/plugin/metrics/IAM/Group/group_member_count.yaml
@@ -14,7 +14,7 @@ query_options:
       name: Group Email
     - key: data.members.preferredMemberKey.id
       name: Member
-    - key: data.members.type
+    - key: data.members.memberType
       name: Member Type
     - key: data.members.role
       name: Role
@@ -23,4 +23,4 @@ query_options:
       operator: count
 unit: Count
 namespace_id: ns-google-cloud-iam-group
-version: '1.0'
+version: '1.1'

--- a/src/plugin/metrics/IAM/Permission/permission_count.yaml
+++ b/src/plugin/metrics/IAM/Permission/permission_count.yaml
@@ -5,7 +5,7 @@ metric_type: GAUGE
 resource_type: inventory.CloudService:google_cloud.IAM.Permission
 query_options:
   group_by:
-    - key: data.type
+    - key: data.memberType
       name: Principal Type
       default: true
     - key: account
@@ -17,4 +17,4 @@ query_options:
       operator: count
 unit: Count
 namespace_id: ns-google-cloud-iam-permission
-version: '1.0'
+version: '1.2'

--- a/src/plugin/metrics/IAM/Permission/rb_count.yaml
+++ b/src/plugin/metrics/IAM/Permission/rb_count.yaml
@@ -7,7 +7,7 @@ query_options:
   unwind:
     path: data.bindings
   group_by:
-    - key: data.type
+    - key: data.memberType
       name: Principal Type
       default: true
     - key: data.memberId
@@ -18,8 +18,6 @@ query_options:
       name: Role Name
     - key: data.bindings.role.roleType
       name: Role Type
-    - key: data.bindings.target.type
-      name: Target Type
     - key: data.bindings.target.location
       name: Location
     - key: data.bindings.target.id
@@ -29,4 +27,4 @@ query_options:
       operator: count
 unit: Count
 namespace_id: ns-google-cloud-iam-permission
-version: '1.0'
+version: '1.2'

--- a/src/plugin/metrics/IAM/Role/role_count.yaml
+++ b/src/plugin/metrics/IAM/Role/role_count.yaml
@@ -5,7 +5,7 @@ metric_type: GAUGE
 resource_type: inventory.CloudService:google_cloud.IAM.Role
 query_options:
   group_by:
-    - key: data.role_type
+    - key: data.roleType
       name: Role Type
       default: true
     - key: account


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- Changed the **data type names**, so that the links from the metric page redirect to the correct cloud service pages with the corresponding filters.
- Removed '**Target Type**' from the **IAM > Permission > Role Binding Count** metric explorer page due to its redundancy.

### Known issue
- A label is not being displayed on the**IAM > Permission > Permission Count** metric explorer page, when `data.inherited == false` (Already reported).