### PR TITLE
Added caching mechanism for member lookup

### DIFF
--- a/src/plugin/manager/iam/group_manager.py
+++ b/src/plugin/manager/iam/group_manager.py
@@ -73,21 +73,22 @@ class GroupManager(ResourceManager):
         members = self.identity_connector.list_memberships(group_id)
         for member in members:
             member_name = member.get("name")
-            last_part_of_name = member_name.split("/")[-1]
+            last_part_of_name = member_name.split("/")[-1].strip()
             if last_part_of_name not in self.member_name_to_member_info:
                 self.member_name_to_member_info[last_part_of_name] = (
                     self.identity_connector.get_membership(member_name)
                 )
             else:
-                saved_mem_id = (
+                cached_mem_id = (
                     self.member_name_to_member_info[last_part_of_name]
                     .get("preferredMemberKey")
                     .get("id")
                 )
                 curr_mem_id = member.get("preferredMemberKey").get("id")
-                if saved_mem_id != curr_mem_id:
+                if cached_mem_id != curr_mem_id:
                     _LOGGER.debug(
-                        f"[{self.__repr__()}] MEMBER_ID: {curr_mem_id} has different member_name: {last_part_of_name} from {saved_mem_id}"
+                        f"[{self.__repr__()}] MEMBER_ID: {curr_mem_id} has different member_name: {last_part_of_name} \
+                        from (cached) {cached_mem_id}: {self.member_name_to_member_info[last_part_of_name]}"
                     )
                     self.member_name_to_member_info[last_part_of_name] = (
                         self.identity_connector.get_membership(member_name)

--- a/src/plugin/manager/iam/group_manager.py
+++ b/src/plugin/manager/iam/group_manager.py
@@ -23,7 +23,7 @@ class GroupManager(ResourceManager):
         self.metadata_path = "metadata/group.yaml"
         self.identity_connector = None
         self.rm_v3_connector = None
-        self.member_name_to_member_info = {}
+        self.membership_name_to_member_info = {}
 
     def collect_cloud_services(
         self, options: dict, secret_data: dict, schema: str
@@ -73,27 +73,27 @@ class GroupManager(ResourceManager):
         members = self.identity_connector.list_memberships(group_id)
         for member in members:
             member_name = member.get("name")
-            last_part_of_name = member_name.split("/")[-1]
-            if last_part_of_name not in self.member_name_to_member_info:
-                self.member_name_to_member_info[last_part_of_name] = (
+            _group_name, membership_name = member_name.split("/memberships/")
+            if membership_name not in self.membership_name_to_member_info:
+                self.membership_name_to_member_info[membership_name] = (
                     self.identity_connector.get_membership(member_name)
                 )
             else:
                 cached_mem_id = (
-                    self.member_name_to_member_info[last_part_of_name]
+                    self.membership_name_to_member_info[membership_name]
                     .get("preferredMemberKey")
                     .get("id")
                 )
                 curr_mem_id = member.get("preferredMemberKey").get("id")
                 if cached_mem_id != curr_mem_id:
                     _LOGGER.debug(
-                        f"[{self.__repr__()}] MEMBER_ID: {curr_mem_id} has different member_name: {last_part_of_name} \
-from (cached) {cached_mem_id}: {self.member_name_to_member_info[last_part_of_name]}"
+                        f"[{self.__repr__()}] MEMBER_ID: {curr_mem_id} has different member_name: {membership_name} \
+from (cached) {cached_mem_id}: {self.membership_name_to_member_info[membership_name]}"
                     )
-                    self.member_name_to_member_info[last_part_of_name] = (
+                    self.membership_name_to_member_info[membership_name] = (
                         self.identity_connector.get_membership(member_name)
                     )
-            member_info = self.member_name_to_member_info[last_part_of_name]
+            member_info = self.membership_name_to_member_info[membership_name]
             if member_info.get("memberType"):
                 member_info["memberType"] = member_info.pop("type")
             roles = member_info.get("roles", [])

--- a/src/plugin/manager/iam/group_manager.py
+++ b/src/plugin/manager/iam/group_manager.py
@@ -73,7 +73,7 @@ class GroupManager(ResourceManager):
         members = self.identity_connector.list_memberships(group_id)
         for member in members:
             member_name = member.get("name")
-            last_part_of_name = member_name.split("/")[-1].strip()
+            last_part_of_name = member_name.split("/")[-1]
             if last_part_of_name not in self.member_name_to_member_info:
                 self.member_name_to_member_info[last_part_of_name] = (
                     self.identity_connector.get_membership(member_name)
@@ -88,7 +88,7 @@ class GroupManager(ResourceManager):
                 if cached_mem_id != curr_mem_id:
                     _LOGGER.debug(
                         f"[{self.__repr__()}] MEMBER_ID: {curr_mem_id} has different member_name: {last_part_of_name} \
-                        from (cached) {cached_mem_id}: {self.member_name_to_member_info[last_part_of_name]}"
+from (cached) {cached_mem_id}: {self.member_name_to_member_info[last_part_of_name]}"
                     )
                     self.member_name_to_member_info[last_part_of_name] = (
                         self.identity_connector.get_membership(member_name)


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
- Added a mapping to check the cache before calling groups().memberships().get(), improving performance by safely reducing redundant lookups.

### Known issue