### PR TITLE
Made 'Analyzer Enabled' field a default field in Service Account table

### DIFF
--- a/src/plugin/metadata/service_account.yaml
+++ b/src/plugin/metadata/service_account.yaml
@@ -46,7 +46,6 @@ table:
         - DISABLED: red.500
           name: Disabled
           type: state
-      is_optional: true
     - Last Activity: data.lastAuthenticated
       type: datetime
       display_format: 'YYYY-MM-DD'


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
- Made the 'Analyzer Enabled' field a default field in the Service Account table

### Known issue