### PR TITLE
Added api-retry decorator to other connectors' get & list methods

### DIFF
--- a/src/plugin/connector/cloud_identity_connector.py
+++ b/src/plugin/connector/cloud_identity_connector.py
@@ -12,6 +12,7 @@ class CloudIdentityConnector(GoogleCloudConnector):
     google_client_service = "cloudidentity"
     version = "v1"
 
+    @api_retry_handler(default_response=[])
     def list_groups(self, customer_id):
         groups = []
         parent = f"customers/{customer_id}"
@@ -26,6 +27,7 @@ class CloudIdentityConnector(GoogleCloudConnector):
                 break
         return groups
 
+    @api_retry_handler(default_response={})
     def get_group(self, name):
         result = self.client.groups().get(name=name).execute()
         return result


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- Added api-retry decorator to other connectors' get & list methods to handle Google's 503 Server Unavailable errors when collecting roles, permissions, and service accounts

### Known issue