### PR TITLE
Implement last_activity feature using Cloud Logging instead of Policy Analyzer

### DIFF
--- a/src/plugin/connector/logging_connector.py
+++ b/src/plugin/connector/logging_connector.py
@@ -1,8 +1,8 @@
 import logging
 from plugin.connector import GoogleCloudConnector
-import requests
-import google.auth.transport.requests
 from plugin.utils.error_handlers import api_retry_handler
+
+from datetime import datetime, timedelta
 
 __all__ = ["LoggingConnector"]
 
@@ -12,6 +12,10 @@ _LOGGER = logging.getLogger("spaceone")
 class LoggingConnector(GoogleCloudConnector):
     google_client_service = "logging"
     version = "v2"
+
+    def __init__(self, options: dict, secret_data: dict, schema: str, *args, **kwargs):
+        super().__init__(options=options, secret_data=secret_data, schema=schema, *args, **kwargs)
+        self.log_search_period = options.get("log_search_period")
 
     @api_retry_handler(default_response=[])
     def list_entries(self, project_id: str) -> list:
@@ -25,57 +29,47 @@ class LoggingConnector(GoogleCloudConnector):
         entries = response.get("entries", [])
         return entries
 
-    def get_all_service_account_last_authenticated_time(self, project_id: str):
-        return self._get_all_service_account_last_authenticated_time(project_id, is_key=False)
+    def get_last_log_entry_timestamp(self, project_id: str, service_account_email: str):
+        log_entries = (self._list_entries_service_accounts(project_id, service_account_email))
+        if not log_entries:
+            return None
+        timestamp = log_entries[0].get("timestamp")
+        return timestamp
 
-    def get_all_service_account_key_last_authenticated_time(self, project_id: str):
-        return self._get_all_service_account_last_authenticated_time(project_id, is_key=True)
+    @api_retry_handler(default_response=[])
+    def _list_entries_service_accounts(self, project_id: str, service_account_email: str) -> list:
+        filter_str = (
+            f"protoPayload.authenticationInfo.principalEmail=\"{service_account_email}\""
+        )
+        filter_str += self._get_timestamp_filter_str(datetime.utcnow())
 
-    @api_retry_handler(default_response={})
-    def _get_all_service_account_last_authenticated_time(self, project_id: str, is_key: bool):
-        activity_type = "serviceAccountLastAuthentication" if not is_key else "serviceAccountKeyLastAuthentication"
-        page_size = 1000
-        url = f"https://policyanalyzer.googleapis.com/v1/projects/{project_id}/locations/global/activityTypes/{activity_type}/activities:query?pageSize={page_size}"
-        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-        credentials = self.credentials.with_scopes(scopes)
-        request = google.auth.transport.requests.Request()
-        credentials.refresh(request)
-        token = credentials.token
-        headers = {
-            "Authorization": f"Bearer {token}"
+        body = {
+            "resourceNames": [f"projects/{project_id}"],
+            "orderBy": "timestamp desc",
+            "pageSize": 1,
+            "filter": filter_str,
         }
-        sa_id_to_last_authenticated_time = {}
-        next_page_token = ""
-        while True:
-            response = requests.get(url+next_page_token, headers=headers)
-            if response.status_code != 200:
-                error_message = f"API request failed with status code {response.status_code}: {response.text}"
-                _LOGGER.debug(f"[{self.__repr__()}] Error: {error_message}", exc_info=True)
-                if response.status_code == 403:
-                    return None
-                return sa_id_to_last_authenticated_time
-            activities = response.json().get('activities', [])
-            if not activities:
-                break
-            for one_sa_dict in activities:
+        response = self.client.entries().list(body=body).execute()
+        entries = response.get("entries", [])
+        return entries
 
-                sa_id = one_sa_dict.get('activity', {}).get('serviceAccount', {}).get('serviceAccountId', '')
-                sa_id = sa_id if sa_id else one_sa_dict.get('activity', {}).get('serviceAccountKey', {}).get('serviceAccountId', '')
+    def _get_timestamp_filter_str(self, time_now: datetime) -> str:
+        if self.log_search_period == "1 Month":
+            log_search_period_in_days = 31
+        elif self.log_search_period == "3 Months":
+            log_search_period_in_days = 92
+        elif self.log_search_period == "6 Months":
+            log_search_period_in_days = 183
+        else:
+            log_search_period_in_days = 365
 
-                last_authenticated_time = one_sa_dict.get('activity', {}).get('lastAuthenticatedTime', '')
-
-                if is_key:
-
-                    key_id = one_sa_dict.get('fullResourceName', '').split("/")[-1]
-
-                    if sa_id not in sa_id_to_last_authenticated_time:
-                        sa_id_to_last_authenticated_time[sa_id] = {}
-                    sa_id_to_last_authenticated_time[sa_id][key_id] = last_authenticated_time
-                else:
-                    sa_id_to_last_authenticated_time[sa_id] = last_authenticated_time
-
-            next_page_token = response.json().get('nextPageToken')
-            if not next_page_token:
-                break
-            url += "&pageToken="
-        return sa_id_to_last_authenticated_time
+        start_time, end_time = time_now - timedelta(days=log_search_period_in_days), time_now
+        start_time_str, end_time_str = (
+            start_time.isoformat().split(".")[0] + "Z",
+            end_time.isoformat().split(".")[0] + "Z",
+        )
+        timestamp_filter = (
+            f' AND timestamp >= "{start_time_str}"'
+            f' AND timestamp <= "{end_time_str}"'
+        )
+        return timestamp_filter

--- a/src/plugin/main.py
+++ b/src/plugin/main.py
@@ -48,6 +48,21 @@ def _create_init_metadata() -> dict:
                 "inventory.Region",
                 "inventory.ErrorResource",
             ],
+
+            "options_schema": {
+                "type": "object",
+                "properties": {
+                    "log_search_period": {
+                        "title": "Log Search Period for Service Accounts",
+                        "type": "string",
+                        "items": {"type": "string"},
+                        "default": "3 Months",
+                        "enum": ["1 Month", "3 Months", "6 Months", "1 Year"],
+                        "description": "Select the period to search for the last activity log for the service accounts.\
+ The longer the period, the longer it will take to collect data.",
+                    }
+                }
+            },
         }
     }
 

--- a/src/plugin/metadata/service_account.yaml
+++ b/src/plugin/metadata/service_account.yaml
@@ -37,18 +37,9 @@ table:
     - Description: data.description
       is_optional: true
     - Key Count: data.keyCount
-    - Analyzer Enabled: data.policyAnalyzerEnabled
-      type: enum
-      enums:
-        - ENABLED: green.500
-          name: Enabled
-          type: state
-        - DISABLED: red.500
-          name: Disabled
-          type: state
-    - Last Activity: data.lastAuthenticated
+    - Last Activity: data.lastActivityTime
       type: datetime
-      display_format: 'YYYY-MM-DD'
+      display_format: 'YYYY-MM-DD HH:mm:ss'
       source_type: iso8601
     - OAuth2 Client ID: data.oauth2ClientId
     - Google Project ID: account
@@ -113,10 +104,6 @@ tabs.1:
         - "EXPIRED": red.500
           name: Expired
           type: state
-    - Last Activity: data.lastAuthenticated
-      type: datetime
-      display_format: 'YYYY-MM-DD'
-      source_type: iso8601
     - Type: keyOrigin
       type: enum
       enums:


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
- Implemented the `last_activity` feature using Cloud Logging instead of Policy Analyzer
- Discarded a former implementation and related metadata
    - Since Policy Analyzer requires users to explicitly enable the API to get the last authenticated time and has some other cons

### Known issue