### PR TITLE
Added `IAMConnector.get_role` for rare deprecated roles that cannot be retrieved via list calls + Removed `lastActivity` related fields for each service account keys + Added `table.options.default_filter` field in metadata

### DIFF
--- a/src/plugin/connector/iam_connector.py
+++ b/src/plugin/connector/iam_connector.py
@@ -119,7 +119,6 @@ class IAMConnector(GoogleCloudConnector):
     def list_roles(self):
         roles = []
         request = self.client.roles().list(pageSize=1000, view="FULL")
-
         while True:
             response = request.execute()
             roles.extend(response.get("roles", []))
@@ -132,3 +131,8 @@ class IAMConnector(GoogleCloudConnector):
                 break
 
         return roles
+
+    @api_retry_handler(default_response={})
+    @cache.cacheable(key="plugin:connector:role:{name}", alias="local")
+    def get_role(self, name: str):
+        return self.client.roles().get(name=name).execute()

--- a/src/plugin/manager/iam/permission_manager.py
+++ b/src/plugin/manager/iam/permission_manager.py
@@ -67,14 +67,9 @@ class PermissionManager(ResourceManager):
                     project["projectId"]
                 )
 
-        pre_role_id_to_info = {role.get("name"): role for role in predefined_roles}
-        self.role_id_to_info["predefined_roles"] = pre_role_id_to_info
-
-        org_role_id_to_info = {role.get("name"): role for role in organization_roles}
-        self.role_id_to_info["organization_roles"] = org_role_id_to_info
-
-        pro_role_id_to_info = {role.get("name"): role for role in project_roles}
-        self.role_id_to_info["project_roles"] = pro_role_id_to_info
+        self.role_id_to_info["predefined_roles"] = {role.get("name"): role for role in predefined_roles}
+        self.role_id_to_info["organization_roles"] = {role.get("name"): role for role in organization_roles}
+        self.role_id_to_info["project_roles"] = {role.get("name"): role for role in project_roles}
 
         # Get service account info
         self.get_service_account_info()
@@ -175,6 +170,9 @@ class PermissionManager(ResourceManager):
         else:
             role_details = self.role_id_to_info["predefined_roles"].get(role_id)
             role_type = "PREDEFINED"
+            if not role_details:
+                role_details = self.iam_connector.get_role(role_id)
+                self.role_id_to_info["predefined_roles"][role_id] = role_details
 
         binding_info["role"] = {
             "id": role_details.get("name"),

--- a/src/plugin/manager/iam/service_account_manager.py
+++ b/src/plugin/manager/iam/service_account_manager.py
@@ -74,9 +74,9 @@ class ServiceAccountManager(ResourceManager):
             if service_account["lastActivityTime"]
             else f"No activity log found in the past {self.logging_connector.log_search_period.lower()}"
         )
-        # keys = self.get_service_account_keys(email, project_id)
-        # service_account["keys"] = keys
-        # service_account["keyCount"] = len(keys)
+        keys = self.get_service_account_keys(email, project_id)
+        service_account["keys"] = keys
+        service_account["keyCount"] = len(keys)
 
         return make_cloud_service(
             name=name,
@@ -100,16 +100,6 @@ class ServiceAccountManager(ResourceManager):
             key_full_name = key.get("name")
             key["name"] = key_full_name.split("/")[-1]
             key["status"] = "ACTIVE"
-            key["lastActivityTime"] = (
-                self.logging_connector.get_last_log_entry_timestamp(
-                    project_id, email, key_full_name
-                )
-            )
-            key["lastActivityDescription"] = (
-                f"Activity log found in the past {self.logging_connector.log_search_period.lower()}"
-                if key["lastActivityTime"]
-                else f"No activity log found in the past {self.logging_connector.log_search_period.lower()}"
-            )
 
             creation_time = key.get("validAfterTime")
             expiration_time = key.get("validBeforeTime")

--- a/src/plugin/metadata/permission.yaml
+++ b/src/plugin/metadata/permission.yaml
@@ -41,6 +41,11 @@ search:
           label: Project
 
 table:
+  options:
+    default_filter:
+      - key: data.memberType
+        value: googleManagedServiceAccount
+        operator: not
   sort:
     key: data.memberType
   fields:

--- a/src/plugin/metadata/service_account.yaml
+++ b/src/plugin/metadata/service_account.yaml
@@ -10,7 +10,7 @@ search:
         - STATE_UNSPECIFIED: gray.500
           label: Unspecified
     - Email: data.email
-#    - Key Count: data.keyCount
+    - Key Count: data.keyCount
       data_type: integer
     - OAuth2 Client ID: data.oauth2ClientId
     - Google Project ID: account
@@ -36,7 +36,7 @@ table:
     - Email: data.email
     - Description: data.description
       is_optional: true
-#    - Key Count: data.keyCount
+    - Key Count: data.keyCount
     - Last Activity: data.lastActivityTime
       type: datetime
       display_format: 'YYYY-MM-DD HH:mm:ss'
@@ -70,55 +70,50 @@ tabs.0:
     - Google Project ID: account
     - Unique ID: data.uniqueId
 
-#tabs.1:
-#  name: Keys
-#  type: query-search-table
-#  root_path: data.keys
-#  unwind: data.keys
-#  search:
-#    - key: data.keys.name
-#      name: Name
-#    - key: data.keys.status
-#      name: Status
-#      enums:
-#        ACTIVE:
-#          label: Active
-#        EXPIRED:
-#          label: Expired
-#    - key: data.keys.keyOrigin
-#      name: Key Origin
-#      enums:
-#        IMPORTED:
-#          label: Uploaded Key
-#        GOOGLE_PROVIDED:
-#          label: Generated Key
-#    - key: data.keys.keyAlgorithm
-#      name: Key Algorithm
-#  fields:
-#    - Name: name
-#    - Status: status
-#      type: enum
-#      enums:
-#        - "ACTIVE": green.500
-#          name: Active
-#          type: state
-#        - "EXPIRED": red.500
-#          name: Expired
-#          type: state
-#    - Type: keyOrigin
-#      type: enum
-#      enums:
-#        - IMPORTED: blue.500
-#          name: Uploaded Key
-#        - GOOGLE_PROVIDED: coral.500
-#          name: Generated Key
-#    - Last Activity: lastActivityTime
-#      type: datetime
-#      display_format: 'YYYY-MM-DD HH:mm:ss'
-#      source_type: iso8601
-#    - Last Activity Description: lastActivityDescription
-#    - Creation date: validAfterTime
-#      type: datetime
-#    - Expiration date: validBeforeTime
-#      type: datetime
-#    - Key Algorithm: keyAlgorithm
+tabs.1:
+  name: Keys
+  type: query-search-table
+  root_path: data.keys
+  unwind: data.keys
+  search:
+    - key: data.keys.name
+      name: Name
+    - key: data.keys.status
+      name: Status
+      enums:
+        ACTIVE:
+          label: Active
+        EXPIRED:
+          label: Expired
+    - key: data.keys.keyOrigin
+      name: Key Origin
+      enums:
+        IMPORTED:
+          label: Uploaded Key
+        GOOGLE_PROVIDED:
+          label: Generated Key
+    - key: data.keys.keyAlgorithm
+      name: Key Algorithm
+  fields:
+    - Name: name
+    - Status: status
+      type: enum
+      enums:
+        - "ACTIVE": green.500
+          name: Active
+          type: state
+        - "EXPIRED": red.500
+          name: Expired
+          type: state
+    - Type: keyOrigin
+      type: enum
+      enums:
+        - IMPORTED: blue.500
+          name: Uploaded Key
+        - GOOGLE_PROVIDED: coral.500
+          name: Generated Key
+    - Creation date: validAfterTime
+      type: datetime
+    - Expiration date: validBeforeTime
+      type: datetime
+    - Key Algorithm: keyAlgorithm


### PR DESCRIPTION
### Category
- [x] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [x] etc

### Description
- Added `IAMConnector.get_role` for some rare deprecated predefined roles that do not appear through list calls even with different options
- Skipped last activity time retrieval via Cloud Logging for each service account key after the internal discussion
- Added `table.options.default_filter` field in permissions metadata

### Known issue