### PR TITLE
Removed data sharing mechanism to avoid concurrency issues

### DIFF
--- a/src/plugin/manager/base.py
+++ b/src/plugin/manager/base.py
@@ -20,7 +20,6 @@ __all__ = ["ResourceManager"]
 
 class ResourceManager(BaseManager):
     service = None
-    common_data = {}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/plugin/manager/iam/permission_manager.py
+++ b/src/plugin/manager/iam/permission_manager.py
@@ -45,27 +45,17 @@ class PermissionManager(ResourceManager):
         folders = self.rm_v3_connector.search_folders()
         projects = self.rm_v3_connector.list_all_projects()
 
-        if ResourceManager.common_data.get("are_roles_synced"):
-            predefined_roles = ResourceManager.common_data["role_lists"][
-                "predefined_roles"
-            ]
-            organization_roles = ResourceManager.common_data["role_lists"][
-                "organization_roles"
-            ]
-            project_roles = ResourceManager.common_data["role_lists"]["project_roles"]
-
-        else:
-            predefined_roles = self.iam_connector.list_roles()
-            organization_roles = []
-            for organization in organizations:
-                organization_roles = self.iam_connector.list_organization_roles(
-                    organization["name"]
-                )
-            project_roles = []
-            for project in projects:
-                project_roles = self.iam_connector.list_project_roles(
-                    project["projectId"]
-                )
+        predefined_roles = self.iam_connector.list_roles()
+        organization_roles = []
+        for organization in organizations:
+            organization_roles = self.iam_connector.list_organization_roles(
+                organization["name"]
+            )
+        project_roles = []
+        for project in projects:
+            project_roles = self.iam_connector.list_project_roles(
+                project["projectId"]
+            )
 
         self.role_id_to_info["predefined_roles"] = {role.get("name"): role for role in predefined_roles}
         self.role_id_to_info["organization_roles"] = {role.get("name"): role for role in organization_roles}


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
- Removed data sharing mechanism to avoid concurrency issues
- Even though sharing common data would save unnecessary time spent for the redundant collection of roles, we are removing this mechanism for now to avoid conflicts that can be caused by concurrent requests.

### Known issue